### PR TITLE
Patch 2

### DIFF
--- a/blocks.xml
+++ b/blocks.xml
@@ -3620,7 +3620,7 @@
     <property name="LootList" value="44" />
     <property name="Model" value="Entities/LootContainers/file_cabinetPrefab" />
     <property name="Group" value="Furniture/Decor" />
-	<drop event="Destroy" name="scrapIron" count="3,10" prob="1" />
+	<drop event="Destroy" name="scrapIron" count="1" prob="1" />
   </block>
   <block id="624" name="cooler">
     <property name="Class" value="Loot" />
@@ -3631,7 +3631,7 @@
     <property name="LootList" value="45" />
     <property name="Model" value="LootContainers/cooler" param1="main_mesh" />
     <property name="IsTerrainDecoration" value="true" />
-	<drop event="Destroy" name="scrapIron" count="3,10" prob="1" />
+	<drop event="Destroy" name="scrapIron" count="1" prob="1" />
   </block>
   <block id="625" name="schoolDesk">
     <property name="Material" value="furniture" />

--- a/entityclasses.xml
+++ b/entityclasses.xml
@@ -216,7 +216,7 @@
 		<property name="HandItem"             value="handCopZombie" />
         <property name="MaxHealth"    value="2500" />
         <property name="NightApproachSpeed" value="1.8" />
-		<property name="ExperienceGain" value="30"/>
+		<property name="ExperienceGain" value="200"/>
 		<property name="LootListOnDeath"  value="61" />
     </entity_class>
         

--- a/items.xml
+++ b/items.xml
@@ -674,7 +674,7 @@ ARMOR ATTRIBUTE EXAMPLE
             <property name="Repair_amount" value="2" />
             <property name="Upgrade_hit_offset" value="-2" />
             <property name="Sound_start" value="UseActions/repair_block" />
-            <property name="Allowed_upgrade_items" value="woodPlank,scrapIron,forgedIron,hardwoodPlank" />
+            <property name="Allowed_upgrade_items" value="woodPlank,scrapIron,forgedIron,hardwoodPlank,forgedSteel" />
             <property name="Restricted_upgrade_items" value="concreteMix,uhpconcreteMix" />
         </property>
         <property name="Group" value="Tools/Traps" />
@@ -711,7 +711,7 @@ ARMOR ATTRIBUTE EXAMPLE
             <property name="Repair_amount" value="2" />
             <property name="Upgrade_hit_offset" value="-1" />
             <property name="Sound_start" value="UseActions/repair_block" />
-            <property name="Allowed_upgrade_items" value="woodPlank,scrapIron,forgedIron,hardwoodPlank,ironOre,coalOre" />
+            <property name="Allowed_upgrade_items" value="woodPlank,scrapIron,forgedIron,hardwoodPlank,ironOre,coalOre,forgedSteel" />
             <property name="Restricted_upgrade_items" value="concreteMix,uhpconcreteMix" />
         </property>
         <property name="Group" value="Tools/Traps" />
@@ -6222,7 +6222,7 @@ ARMOR ATTRIBUTE EXAMPLE
             <property name="Upgrade_hit_offset" value="-3" />
             <property name="Repair_action_sound" value="Weapons/Motorized/Nailgun/nailgun_fire" />
             <property name="Upgrade_action_sound" value="Weapons/Motorized/Nailgun/nailgun_fire" />
-            <property name="Allowed_upgrade_items" value="woodPlank,scrapIron,forgedIron,hardwoodPlank" />
+            <property name="Allowed_upgrade_items" value="woodPlank,scrapIron,forgedIron,hardwoodPlank,forgedSteel" />
             <property name="Restricted_upgrade_items" value="concrete,concreteMix,uhpconcreteMix" />
         </property>
         <property name="Group" value="Ammo/Weapons" />

--- a/rwgmixer.xml
+++ b/rwgmixer.xml
@@ -67,7 +67,7 @@
 			<property name="RoadRadius" value="7" />
 		</hub>
 		
-		<hub name="town" prob="0.2">
+		<hub name="town" prob="0.35">
 			<property name="MinCityBlockSizeInMeters" value="103,103" />
 			<property name="MaxCityBlockSizeInMeters" value="412,412" />
 			
@@ -102,7 +102,7 @@
 			<property name="RoadRadius" value="7" /> 
 		</hub>
 		
-		<hub name="town" prob="0.2">
+		<hub name="town" prob="0.35">
 			<property name="MinCityBlockSizeInMeters" value="103,103" /> 
 			<property name="MaxCityBlockSizeInMeters" value="412,412" /> 
 			
@@ -137,7 +137,7 @@
 			<property name="RoadRadius" value="7" /> 
 		</hub>
 		
-		<hub name="town" prob="0.2">
+		<hub name="town" prob="0.35">
 			<property name="MinCityBlockSizeInMeters" value="103,103" /> 
 			<property name="MaxCityBlockSizeInMeters" value="412,412" /> 
 			
@@ -172,7 +172,7 @@
 			<property name="RoadRadius" value="7" /> 
 		</hub>
 		
-		<hub name="town" prob="0.2">
+		<hub name="town" prob="0.35">
 			<property name="MinCityBlockSizeInMeters" value="103,103" /> 
 			<property name="MaxCityBlockSizeInMeters" value="412,412" /> 
 			
@@ -207,7 +207,7 @@
 			<property name="RoadRadius" value="7" /> 
 		</hub>
 		
-		<hub name="town" prob="0.2">
+		<hub name="town" prob="0.35">
 			<property name="MinCityBlockSizeInMeters" value="103,103" /> 
 			<property name="MaxCityBlockSizeInMeters" value="412,412" /> 
 			
@@ -242,7 +242,7 @@
 			<property name="RoadRadius" value="7" /> 
 		</hub>
 		
-		<hub name="town" prob="0.2">
+		<hub name="town" prob="0.35">
 			<property name="MinCityBlockSizeInMeters" value="103,103" /> 
 			<property name="MaxCityBlockSizeInMeters" value="412,412" /> 
 			

--- a/spawning.xml
+++ b/spawning.xml
@@ -581,50 +581,50 @@
 		<day value="1">
 			<property name="EntityGroupName"    value="ZombiesAll" />
 			<property name="Time"               value="Any" />
-			<property name="DelayBetweenSpawns" value="1" />
-			<property name="TotalAlive"         value="0" />
-			<property name="TotalPerWave"       value="1,5" />
+			<property name="DelayBetweenSpawns" value="3" />
+			<property name="TotalAlive"         value="3" />
+			<property name="TotalPerWave"       value="3" />
 		</day>
 		<day value="2">
 		  <property name="EntityGroupName"    value="ZombiesAll" />
 		  <property name="Time"               value="Any" />
 		  <property name="DelayBetweenSpawns" value="1" />
-		  <property name="TotalAlive"         value="0" />
-		  <property name="TotalPerWave"       value="5,10" />
+		  <property name="TotalAlive"         value="5" />
+		  <property name="TotalPerWave"       value="5" />
 		</day>
 		<day value="3">
 		  <property name="EntityGroupName"    value="ZombiesAll" />
 		  <property name="Time"               value="Any" />
 		  <property name="DelayBetweenSpawns" value="1" />
-		  <property name="TotalAlive"         value="0" />
-		  <property name="TotalPerWave"       value="10,15" />
+		  <property name="TotalAlive"         value="10" />
+		  <property name="TotalPerWave"       value="20" />
 		</day>
 		<day value="4">
 		  <property name="EntityGroupName"    value="ZombiesAll" />
 		  <property name="Time"               value="Any" />
 		  <property name="DelayBetweenSpawns" value="1" />
-		  <property name="TotalAlive"         value="10" />
+		  <property name="TotalAlive"         value="15" />
 		  <property name="TotalPerWave"       value="10,20" />
 		</day>
 		<day value="5">
 		  <property name="EntityGroupName"    value="ZombiesAll" />
 		  <property name="Time"               value="Any" />
 		  <property name="DelayBetweenSpawns" value="1" />
-		  <property name="TotalAlive"         value="0" />
+		  <property name="TotalAlive"         value="15" />
 		  <property name="TotalPerWave"       value="10,30" />
 		</day>
 		<day value="6">
 		  <property name="EntityGroupName"    value="ZombieDogGroup" />
 		  <property name="Time"               value="Any" />
 		  <property name="DelayBetweenSpawns" value="1" />
-		  <property name="TotalAlive"         value="0" />
+		  <property name="TotalAlive"         value="10" />
 		  <property name="TotalPerWave"       value="10,20" />
 		</day>
 		<day value="7">
 		  <property name="EntityGroupName"    value="ZombiesAll" />
 		  <property name="Time"               value="Any" />
 		  <property name="DelayBetweenSpawns" value="1" />
-		  <property name="TotalAlive"         value="0" />
+		  <property name="TotalAlive"         value="15" />
 		  <property name="TotalPerWave"       value="30,40" />
 		</day>	
 		<day value="8">
@@ -642,51 +642,51 @@
 			<property name="EntityGroupName"    value="ZombiesNight" />
 			<property name="Time"               value="Any" />
 			<property name="DelayBetweenSpawns" value="1" />
-			<property name="TotalAlive"         value="3" />
+			<property name="TotalAlive"         value="4" />
 			<property name="TotalPerWave"       value="4" />
 		</day>
 		<day value="2">
 		  <property name="EntityGroupName"    value="ZombiesNight" />
 		  <property name="Time"               value="Any" />
 		  <property name="DelayBetweenSpawns" value="1" />
-		  <property name="TotalAlive"         value="0" />
-		  <property name="TotalPerWave"       value="7" />
+		  <property name="TotalAlive"         value="10" />
+		  <property name="TotalPerWave"       value="10" />
 		</day>
 		<day value="3">
 		  <property name="EntityGroupName"    value="ZombiesNight" />
 		  <property name="Time"               value="Any" />
 		  <property name="DelayBetweenSpawns" value="1" />
-		  <property name="TotalAlive"         value="8" />
-		  <property name="TotalPerWave"       value="10" />
+		  <property name="TotalAlive"         value="15" />
+		  <property name="TotalPerWave"       value="15" />
 		</day>
 		<day value="4">
 		  <property name="EntityGroupName"    value="ZombiesNight" />
 		  <property name="Time"               value="Any" />
 		  <property name="DelayBetweenSpawns" value="1" />
-		  <property name="TotalAlive"         value="0" />
+		  <property name="TotalAlive"         value="15" />
 		  <property name="TotalPerWave"       value="15" />
 		</day>
 		<day value="5">
 		  <property name="EntityGroupName"    value="ZombiesNight" />
 		  <property name="Time"               value="Any" />
 		  <property name="DelayBetweenSpawns" value="1" />
-		  <property name="TotalAlive"         value="0" />
+		  <property name="TotalAlive"         value="12" />
 		  <property name="TotalPerWave"       value="20" />
 		</day>
 		<day value="6">
 		  <property name="EntityGroupName"    value="ZombiesNight" />
 		  <property name="Time"               value="Any" />
 		  <property name="DelayBetweenSpawns" value="1" />
-		  <property name="TotalAlive"         value="0" />
-		  <property name="TotalPerWave"       value="0,10" />
+		  <property name="TotalAlive"         value="15" />
+		  <property name="TotalPerWave"       value="25" />
 		</day>
 		
 		<day value="7">
 		  <property name="EntityGroupName"    value="ZombiesHoard" />
 		  <property name="Time"               value="Any" />
 		  <property name="DelayBetweenSpawns" value="1" />
-		  <property name="TotalAlive"         value="25" />
-		  <property name="TotalPerWave"       value="20,40" />
+		  <property name="TotalAlive"         value="18" />
+		  <property name="TotalPerWave"       value="40" />
 		</day>		
 
 	</entityspawner>
@@ -696,8 +696,8 @@
 			<property name="ResetToday"         value="true" />
 			<property name="EntityGroupName"    value="ZombiesNight" />
 			<property name="DelayBetweenSpawns" value="1" />
-			<property name="TotalAlive"         value="0" />
-			<property name="TotalPerWave"       value="0" />
+			<property name="TotalAlive"         value="5" />
+			<property name="TotalPerWave"       value="5" />
 		</day>
 		<day value="7">
 			<property name="ResetToday"         value="true" />


### PR DESCRIPTION
forgedSteel had been left out of Allowed_upgrade_items which caused people with UHPConcrete to not be able to upgrade their concrete to make a steel frame for their doors.

(This was tested and confirmed on my local copy of the server - unfortunately I found a new issue - steelWall doesn't have a downgrade path and metal_steel material only has a hardness of 15, making it the weakest point of uhpConcrete)